### PR TITLE
Put entrypoint in /, use COPY instead of ADD

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -65,7 +65,7 @@ RUN set -ex; \
 
 # Configure container
 USER flink
-ADD docker-entrypoint.sh $FLINK_HOME/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 6123 8081
 CMD ["help"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -58,7 +58,7 @@ RUN set -ex; \
 
 # Configure container
 USER flink
-ADD docker-entrypoint.sh $FLINK_HOME/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 6123 8081
 CMD ["help"]


### PR DESCRIPTION
I'm inclined not to mess with anything in the Flink release directory
if we don't have to. Additionally, there is precedent for putting
`docker-entrypoint.sh` in `/`, including the Docker official images
documentation[1].

ADD has some weird behaviors (such as supporting URLs) while COPY
does only what it says on the tin, which is what we want here.

[1]https://github.com/docker-library/official-images/#consistency