### PR TITLE
Step-down from root in docker-entrypoint.sh

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -30,7 +30,6 @@ RUN addgroup -S -g 9999 flink && \
     adduser -D -S -H -u 9999 -G flink -h $FLINK_HOME flink
 WORKDIR $FLINK_HOME
 
-# Install build dependencies and flink
 ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala_${SCALA_VERSION}.tgz
 # Not all mirrors have the .asc files
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
@@ -39,7 +38,10 @@ ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename
 # For GPG verification instead of relying on key servers
 COPY KEYS /KEYS
 
-RUN apk add --no-cache bash snappy
+# Install dependencies, Bash, and su-exec for easy step-down from root
+RUN apk add --no-cache bash snappy 'su-exec>=0.2'
+
+# Install Flink
 RUN set -ex; \
   apk add --no-cache --virtual .build-deps \
     ca-certificates \
@@ -64,7 +66,6 @@ RUN set -ex; \
   chown -R flink:flink .;
 
 # Configure container
-USER flink
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 6123 6124 8081

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -30,7 +30,6 @@ RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR $FLINK_HOME
 
-# Install build dependencies and flink
 ENV FLINK_URL_FILE_PATH=flink/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-hadoop${HADOOP_VERSION}-scala_${SCALA_VERSION}.tgz
 # Not all mirrors have the .asc files
 ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename=${FLINK_URL_FILE_PATH} \
@@ -39,9 +38,25 @@ ENV FLINK_TGZ_URL=https://www.apache.org/dyn/closer.cgi?action=download&filename
 # For GPG verification instead of relying on key servers
 COPY KEYS /KEYS
 
-RUN apt-get update && \
-  apt-get -y install libsnappy1 && \
+# Grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -ex; \
+  wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)"; \
+  wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc"; \
+  export GNUPGHOME="$(mktemp -d)"; \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+  gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+  rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+  chmod +x /usr/local/bin/gosu; \
+  gosu nobody true
+
+# Install dependencies
+RUN set -ex; \
+  apt-get update; \
+  apt-get -y install libsnappy1; \
   rm -rf /var/lib/apt/lists/*
+
+# Install Flink
 RUN set -ex; \
   wget -nv -O flink.tgz "$FLINK_TGZ_URL"; \
   wget -nv -O flink.tgz.asc "$FLINK_ASC_URL"; \
@@ -57,7 +72,6 @@ RUN set -ex; \
   chown -R flink:flink .;
 
 # Configure container
-USER flink
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 6123 6124 8081

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,6 +21,16 @@
 # If unspecified, the hostname of the container is taken as the JobManager address
 JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-$(hostname -f)}
 
+drop_privs_cmd() {
+    if [ -x /sbin/su-exec ]; then
+        # Alpine
+        echo su-exec
+    else
+        # Others
+        echo gosu
+    fi
+}
+
 if [ "$1" = "help" ]; then
     echo "Usage: $(basename "$0") (jobmanager|taskmanager|local|help)"
     exit 0
@@ -30,7 +40,7 @@ elif [ "$1" = "jobmanager" ]; then
     echo "blob.server.port: 6124" >> "$FLINK_HOME/conf/flink-conf.yaml"
 
     echo "config file: " && grep '^[^\n#]' "$FLINK_HOME/conf/flink-conf.yaml"
-    "$FLINK_HOME/bin/jobmanager.sh" start cluster
+    $(drop_privs_cmd) flink "$FLINK_HOME/bin/jobmanager.sh" start cluster
 
     # prevent script from exiting
     tail -f /dev/null
@@ -41,13 +51,13 @@ elif [ "$1" = "taskmanager" ]; then
 
     echo "Starting Task Manager"
     echo "config file: " && grep '^[^\n#]' "$FLINK_HOME/conf/flink-conf.yaml"
-    "$FLINK_HOME/bin/taskmanager.sh" start
+    $(drop_privs_cmd) flink "$FLINK_HOME/bin/taskmanager.sh" start
 
     # prevent script from exiting
     tail -f /dev/null
 elif [ "$1" = "local" ]; then
     echo "Starting local cluster"
-    "$FLINK_HOME/bin/start-local.sh"
+    $(drop_privs_cmd) flink "$FLINK_HOME/bin/start-local.sh"
 
     # prevent script from exiting
     tail -f /dev/null


### PR DESCRIPTION
Use gosu (debian) or su-exec (alpine) to step-down from root in
docker-entrypoint.sh. This way, if a user runs a non-Flink command,
it is run as root.

Closes #5

The changes to docker-entrypoint.sh will be reworked when 1.2.1 is released and we have proper foreground support.