### PR TITLE
Change the base image to openjdk:8-jre-slim

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -16,7 +16,13 @@
 # limitations under the License.
 ###############################################################################
 
-FROM openjdk:8-jre
+FROM openjdk:8-jre-slim
+
+# Install dependencies
+RUN set -ex; \
+  apt-get update; \
+  apt-get -y install gnupg libsnappy1v5 wget; \
+  rm -rf /var/lib/apt/lists/*
 
 # Grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
@@ -26,15 +32,9 @@ RUN set -ex; \
   export GNUPGHOME="$(mktemp -d)"; \
   gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-  rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+  rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
   chmod +x /usr/local/bin/gosu; \
   gosu nobody true
-
-# Install dependencies
-RUN set -ex; \
-  apt-get update; \
-  apt-get -y install libsnappy1v5; \
-  rm -rf /var/lib/apt/lists/*
 
 # Configure Flink version
 ENV FLINK_VERSION=%%FLINK_VERSION%% \
@@ -64,7 +64,7 @@ RUN set -ex; \
   export GNUPGHOME="$(mktemp -d)"; \
   gpg --import /KEYS; \
   gpg --batch --verify flink.tgz.asc flink.tgz; \
-  rm -r "$GNUPGHOME" flink.tgz.asc; \
+  rm -rf "$GNUPGHOME" flink.tgz.asc; \
   \
   tar -xf flink.tgz --strip-components=1; \
   rm flink.tgz; \


### PR DESCRIPTION
@patricklucas can you take a look, this reduces the image in around 100MB so it is a good improvement I think and we don't add too much complexity so I think it is worth.