### PR TITLE
Use openjdk:8-jre as the default base image for debian (instead of -slim)

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM openjdk:8-jre-slim
+FROM openjdk:8-jre
 
 # Install dependencies
 RUN set -ex; \


### PR DESCRIPTION
The current practice on docker images is to create a different
Dockerfile for the slim image, so better the keep the default as it is.

@patricklucas I know that this contradicts our previous discussion but I think is wise
to have the expected behavior in particular now that Flink 1.4 is been released soon.
Also if the priority is size the alpine image will cover this so in any case it will be easy
to introduce a -slim variant in the future.