### PR TITLE
Implicitly support arches available upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,34 @@ Example
     $ rm -r 1.2
     $ ./add-version.sh -r 1.2 -f 1.2.1
 
+
+Stackbrew Manifest
+------------------
+
+`generate-stackbrew-library.sh` is used to generate the library file required for official Docker
+Hub images.
+
+When this repo is updated, the output of this script should be used to replaced the contents of
+`library/flink` in the Docker [official-images](https://github.com/docker-library/official-images)
+repo via a PR.
+
+Note: running this script requires the `bashbrew` binary and a compatible version of Bash. The
+Docker image `plucas/docker-flink-build` contains these dependencies and can be used to run this
+script.
+
+Example:
+
+    docker run --rm \
+        --volume /path/to/docker-flink:/build \
+        plucas/docker-flink-build \
+        /build/generate-stackbrew-library.sh \
+    > /path/to/official-images/library/flink
+
+
 License
 -------
 
 Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0
 
-Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either registered trademarks or trademarks of The Apache Software Foundation.
+Apache Flink, Flink®, Apache®, the squirrel logo, and the Apache feather logo are either
+registered trademarks or trademarks of The Apache Software Foundation.


### PR DESCRIPTION
Borrow some code from openjdk's version of this script (from which
this image is downstream) to automatically determine the architectures
supported by the upstream image.

Closes #41