### PR TITLE
Build reliability improvements

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -55,6 +55,7 @@ RUN set -ex; \
   export GNUPGHOME="$(mktemp -d)"; \
   gpg --import /KEYS; \
   gpg --batch --verify flink.tgz.asc flink.tgz; \
+  gpgconf --kill all; \
   rm -rf "$GNUPGHOME" flink.tgz.asc; \
   \
   tar -xf flink.tgz --strip-components=1; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -38,6 +38,7 @@ RUN set -ex; \
       gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
   done && \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+  gpgconf --kill all; \
   rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
   chmod +x /usr/local/bin/gosu; \
   gosu nobody true
@@ -69,6 +70,7 @@ RUN set -ex; \
   export GNUPGHOME="$(mktemp -d)"; \
   gpg --import /KEYS; \
   gpg --batch --verify flink.tgz.asc flink.tgz; \
+  gpgconf --kill all; \
   rm -rf "$GNUPGHOME" flink.tgz.asc; \
   \
   tar -xf flink.tgz --strip-components=1; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -30,7 +30,13 @@ RUN set -ex; \
   wget -nv -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)"; \
   wget -nv -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc"; \
   export GNUPGHOME="$(mktemp -d)"; \
-  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+  for server in $(shuf -e ha.pool.sks-keyservers.net \
+                          hkp://p80.pool.sks-keyservers.net:80 \
+                          keyserver.ubuntu.com \
+                          hkp://keyserver.ubuntu.com:80 \
+                          pgp.mit.edu) ; do \
+      gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+  done && \
   gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
   rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
   chmod +x /usr/local/bin/gosu; \


### PR DESCRIPTION
* Fetch gosu GPG key more reliably (#60)
* Kill GPG daemons before cleaning GNUGPGHOME (#59)