### PR TITLE
Install netcat

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -21,7 +21,7 @@ FROM openjdk:8-jre
 # Install dependencies
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install libsnappy1v5; \
+  apt-get -y install libsnappy1v5 netcat; \
   rm -rf /var/lib/apt/lists/*
 
 # Grab gosu for easy step-down from root


### PR DESCRIPTION
The [quick start](https://ci.apache.org/projects/flink/flink-docs-release-1.6/quickstart/setup_quickstart.html) tutorial requires netcat.