### PR TITLE
Support running as non-root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ services:
 - docker
 
 script:
-- testing/smoke_test_all_images.sh
+- testing/run_travis_tests.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,12 +22,15 @@
 JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-$(hostname -f)}
 
 drop_privs_cmd() {
-    if [ -x /sbin/su-exec ]; then
+    if [ $(id -u) != 0 ]; then
+        # Don't need to drop privs if EUID != 0
+        return
+    elif [ -x /sbin/su-exec ]; then
         # Alpine
-        echo su-exec
+        echo su-exec flink
     else
         # Others
-        echo gosu
+        echo gosu flink
     fi
 }
 
@@ -42,7 +45,7 @@ elif [ "$1" = "jobmanager" ]; then
     echo "query.server.port: 6125" >> "$FLINK_HOME/conf/flink-conf.yaml"
 
     echo "config file: " && grep '^[^\n#]' "$FLINK_HOME/conf/flink-conf.yaml"
-    exec $(drop_privs_cmd) flink "$FLINK_HOME/bin/jobmanager.sh" start-foreground "$@"
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/jobmanager.sh" start-foreground "$@"
 elif [ "$1" = "taskmanager" ]; then
     TASK_MANAGER_NUMBER_OF_TASK_SLOTS=${TASK_MANAGER_NUMBER_OF_TASK_SLOTS:-$(grep -c ^processor /proc/cpuinfo)}
 
@@ -53,7 +56,7 @@ elif [ "$1" = "taskmanager" ]; then
 
     echo "Starting Task Manager"
     echo "config file: " && grep '^[^\n#]' "$FLINK_HOME/conf/flink-conf.yaml"
-    exec $(drop_privs_cmd) flink "$FLINK_HOME/bin/taskmanager.sh" start-foreground
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/taskmanager.sh" start-foreground
 fi
 
 exec "$@"

--- a/testing/run_travis_tests.sh
+++ b/testing/run_travis_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=$( cd $( dirname "$0" ) && pwd )
+
+. "${SCRIPT_DIR}/testing_lib.sh"
+
+IS_PULL_REQUEST=
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  IS_PULL_REQUEST=1
+fi
+
+BRANCH="$TRAVIS_BRANCH"
+
+if [ -z "$IS_PULL_REQUEST" ] && [ "$BRANCH" = "master" ]; then
+  # Test all images on master
+  smoke_test_all_images
+  smoke_test_non_root
+else
+  # For pull requests and branches, test one image
+  smoke_test_one_image
+fi

--- a/testing/run_travis_tests.sh
+++ b/testing/run_travis_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-SCRIPT_DIR=$( cd $( dirname "$0" ) && pwd )
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 . "${SCRIPT_DIR}/testing_lib.sh"
 

--- a/testing/testing_lib.sh
+++ b/testing/testing_lib.sh
@@ -36,7 +36,7 @@ function build_image() {
     local image_name="$(image_name "$image_tag")"
     local dockerfile_dir="$(dirname "$dockerfile")"
 
-    echo >&2 "Building ${image_tag} image..."
+    echo >&2 "===> Building ${image_tag} image..."
     docker build -t "$image_name" "$dockerfile_dir"
 }
 
@@ -46,7 +46,7 @@ function run_jobmanager() {
     local image_tag="$(image_tag "$dockerfile")"
     local image_name="$(image_name "$image_tag")"
 
-    echo >&2 "Running ${image_tag} jobmanager..."
+    echo >&2 "===> Starting ${image_tag} jobmanager..."
 
     # Prints container ID
     docker run \
@@ -67,7 +67,7 @@ function run_jobmanager_non_root() {
     local image_tag="$(image_tag "$dockerfile")"
     local image_name="$(image_name "$image_tag")"
 
-    echo >&2 "Running ${image_tag} jobmanager as non-root..."
+    echo >&2 "===> Starting ${image_tag} jobmanager as non-root..."
 
     # Prints container ID
     docker run \
@@ -89,7 +89,7 @@ function wait_for_jobmanager() {
     local image_tag="$(image_tag "$dockerfile")"
 
     i=0
-    echo >&2 "Waiting for ${image_tag} jobmanager to be ready..."
+    echo >&2 "===> Waiting for ${image_tag} jobmanager to be ready..."
     while true; do
         i=$((i+1))
     
@@ -110,14 +110,14 @@ function wait_for_jobmanager() {
         fi
     
         if [ "$i" -gt "$CURL_MAX_TRIES" ]; then
-            echo >&2 "\$CURL_MAX_TRIES exceeded waiting for jobmanager to be ready"
+            echo >&2 "===> \$CURL_MAX_TRIES exceeded waiting for jobmanager to be ready"
             return 1
         fi
 
         sleep "$CURL_COOLDOWN"
     done
 
-    echo >&2 "${image_tag} jobmanager is ready."
+    echo >&2 "===> ${image_tag} jobmanager is ready."
 }
 
 function run_taskmanager() {
@@ -126,7 +126,7 @@ function run_taskmanager() {
     local image_tag="$(image_tag "$dockerfile")"
     local image_name="$(image_name "$image_tag")"
 
-    echo >&2 "Running ${image_tag} taskmanager..."
+    echo >&2 "===> Starting ${image_tag} taskmanager..."
 
     # Prints container ID
     docker run \
@@ -145,7 +145,7 @@ function run_taskmanager_non_root() {
     local image_tag="$(image_tag "$dockerfile")"
     local image_name="$(image_name "$image_tag")"
 
-    echo >&2 "Running ${image_tag} taskmanager as non-root..."
+    echo >&2 "===> Starting ${image_tag} taskmanager as non-root..."
 
     # Prints container ID
     docker run \
@@ -166,7 +166,7 @@ function test_image() {
     local image_tag="$(image_tag "$dockerfile")"
 
     i=0
-    echo >&2 "Waiting for ${image_tag} taskmanager to connect..."
+    echo >&2 "===> Waiting for ${image_tag} taskmanager to connect..."
     while true; do
         i=$((i+1))
     
@@ -186,13 +186,13 @@ function test_image() {
         fi
     
         if [ "$i" -gt "$CURL_MAX_TRIES" ]; then
-            echo >&2 "\$CURL_MAX_TRIES exceeded for taskmanager to connect"
+            echo >&2 "===> \$CURL_MAX_TRIES exceeded for taskmanager to connect"
             return 1
         fi
     
         sleep "$CURL_COOLDOWN"
     done 
-    echo >&2 "${image_tag} taskmanager connected."
+    echo >&2 "===> ${image_tag} taskmanager connected."
 }
 
 function create_network() {
@@ -206,7 +206,7 @@ function cleanup() {
 
     if [ -n "$containers" ]; then
         local num_containers="$(echo "$containers" | awk 'END{print NR}')"
-        echo >&2 -n "Killing ${num_containers} orphaned container(s)..."
+        echo >&2 -n "==> Killing ${num_containers} orphaned container(s)..."
         docker kill $containers > /dev/null
         echo >&2 " done."
     fi
@@ -251,12 +251,12 @@ function smoke_test_one_image() {
     echo >&2 "==> Test one image"
 
     for dockerfile in $dockerfiles; do
-      build_image "$dockerfile"
-      jobmanager_container_id="$(run_jobmanager "$dockerfile")"
-      taskmanager_container_id="$(run_taskmanager "$dockerfile")"
-      wait_for_jobmanager "$dockerfile"
-      test_image "$dockerfile"
-      docker kill "$jobmanager_container_id" "$taskmanager_container_id" > /dev/null
+        build_image "$dockerfile"
+        jobmanager_container_id="$(run_jobmanager "$dockerfile")"
+        taskmanager_container_id="$(run_taskmanager "$dockerfile")"
+        wait_for_jobmanager "$dockerfile"
+        test_image "$dockerfile"
+        docker kill "$jobmanager_container_id" "$taskmanager_container_id" > /dev/null
     done
 }
 
@@ -275,11 +275,13 @@ function smoke_test_non_root() {
     echo >&2 "==> Test images running as non-root"
 
     for dockerfile in $dockerfiles; do
-      build_image "$dockerfile"
-      jobmanager_container_id="$(run_jobmanager_non_root "$dockerfile")"
-      taskmanager_container_id="$(run_taskmanager_non_root "$dockerfile")"
-      wait_for_jobmanager "$dockerfile"
-      test_image "$dockerfile"
-      docker kill "$jobmanager_container_id" "$taskmanager_container_id" > /dev/null
+        build_image "$dockerfile"
+        jobmanager_container_id="$(run_jobmanager_non_root "$dockerfile")"
+        taskmanager_container_id="$(run_taskmanager_non_root "$dockerfile")"
+        wait_for_jobmanager "$dockerfile"
+        test_image "$dockerfile"
+        docker kill "$jobmanager_container_id" "$taskmanager_container_id" > /dev/null
     done
 }
+
+# vim: ts=4 sw=4 et


### PR DESCRIPTION
This changes the `drop_privs_cmd` in `docker-entrypoint.sh` to be a no-op if the effective user id is not 0 (root).

Additionally, I refactored the tests a bit:
* Enable testing PRs by building and testing only one image (the last alphabetically; presumably the latest)
* On master, additionally test one image, in both debian and alpine variants, running as non-root

cc @ndeslandes

Closes #66