### PR TITLE
Add env variables for JM/TM container memory limit

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,6 +60,15 @@ elif [ "$1" = "jobmanager" ]; then
         echo "query.server.port: 6125" >> "${CONF_FILE}"
     fi
 
+    if [ -n "${JOBMANAGER_CONTAINER_MEMORY_LIMIT}" ]; then
+      JOBMANAGER_HEAP_SIZE="$((JOBMANAGER_CONTAINER_MEMORY_LIMIT*80/100))m"
+      if grep -E "^jobmanager\.heap\.size:.*" "${CONF_FILE}" > /dev/null; then
+          sed -i -e "s/^jobmanager\.heap\.size:.*/jobmanager.heap.size: ${JOBMANAGER_HEAP_SIZE}/g" "${CONF_FILE}"
+      else
+          echo "jobmanager.heap.size: ${JOBMANAGER_HEAP_SIZE}" >> "${CONF_FILE}"
+      fi
+    fi
+
     if [ -n "${FLINK_PROPERTIES}" ]; then
         echo "${FLINK_PROPERTIES}" >> "${CONF_FILE}"
     fi
@@ -94,6 +103,15 @@ elif [ "$1" = "taskmanager" ]; then
         sed -i -e "s/query\.server\.port:.*/query.server.port: 6125/g" "${CONF_FILE}"
     else
         echo "query.server.port: 6125" >> "${CONF_FILE}"
+    fi
+
+    if [ -n "${TASKMANAGER_CONTAINER_MEMORY_LIMIT}" ]; then
+      TASKMANAGER_HEAP_SIZE="$((TASKMANAGER_CONTAINER_MEMORY_LIMIT*80/100))m"
+      if grep -E "^taskmanager\.heap\.size:.*" "${CONF_FILE}" > /dev/null; then
+          sed -i -e "s/^taskmanager\.heap\.size:.*/taskmanager.heap.size: ${TASKMANAGER_HEAP_SIZE}/g" "${CONF_FILE}"
+      else
+          echo "taskmanager.heap.size: ${TASKMANAGER_HEAP_SIZE}" >> "${CONF_FILE}"
+      fi
     fi
 
     if [ -n "${FLINK_PROPERTIES}" ]; then


### PR DESCRIPTION
If JOBMANAGER_CONTAINER_MEMORY_LIMIT or TASKMANAGER_CONTAINER_MEMORY_LIMIT
is provided, automatically set JM/TM heap size to 80% of it. If users
don't want this behavior, simply leave them unset and the system will
use the value from flink config.

The intended use case is to be used together with k8s downward API
which could dynamically get the container memory limits and intialize
the env varaibles. This allows us to set JM/TM heap size automatically
based on the container memory limit; otherwise, users have to set
container memory limit and JM/TM heap size separately.