### PR TITLE
Support environment variable substitution for flink-conf.yaml

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -21,7 +21,7 @@ FROM openjdk:8-jre
 # Install dependencies
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install libsnappy1v5; \
+  apt-get -y install libsnappy1v5 gettext-base; \
   rm -rf /var/lib/apt/lists/*
 
 # Grab gosu for easy step-down from root

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,6 +63,7 @@ elif [ "$1" = "jobmanager" ]; then
     if [ -n "${FLINK_PROPERTIES}" ]; then
         echo "${FLINK_PROPERTIES}" >> "${CONF_FILE}"
     fi
+    envsubst < ${CONF_FILE} > ${CONF_FILE}.tmp && mv ${CONF_FILE}.tmp ${CONF_FILE}
 
     echo "config file: " && grep '^[^\n#]' "${CONF_FILE}"
     exec $(drop_privs_cmd) "$FLINK_HOME/bin/jobmanager.sh" start-foreground "$@"
@@ -99,6 +100,7 @@ elif [ "$1" = "taskmanager" ]; then
     if [ -n "${FLINK_PROPERTIES}" ]; then
         echo "${FLINK_PROPERTIES}" >> "${CONF_FILE}"
     fi
+    envsubst < ${CONF_FILE} > ${CONF_FILE}.tmp && mv ${CONF_FILE}.tmp ${CONF_FILE}
 
     echo "config file: " && grep '^[^\n#]' "${CONF_FILE}"
     exec $(drop_privs_cmd) "$FLINK_HOME/bin/taskmanager.sh" start-foreground "$@"


### PR DESCRIPTION
Allowing for environment variable substitution makes the configuration mechanism more flexible and avoids custom entry points / scripting. With FlinkK8sOperator we use it to replace the host names in a way that suites our infrastructure.

See https://github.com/lyft/flinkk8soperator/pull/136
