### PR TITLE
Add ENABLE_BUILT_IN_PLUGINS environment variable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,14 +36,18 @@ drop_privs_cmd() {
 }
 
 copy_plugins_if_required() {
+  if [ -z "$ENABLE_BUILT_IN_PLUGINS" ]; then
+    return 0
+  fi
+
   echo "Enabling required built-in plugins"
-  for TARGET_PLUGIN in $(echo "$ENABLE_BUILT_IN_PLUGINS" | grep -o -e "[^;]*"); do
-    echo "Moving $TARGET_PLUGIN to plugin directory"
-    PLUGIN_NAME=${TARGET_PLUGIN%.jar}
-    if mkdir "${FLINK_HOME}/plugins/${PLUGIN_NAME}" && cp "${FLINK_HOME}/opt/${TARGET_PLUGIN}" "${FLINK_HOME}/plugins/${PLUGIN_NAME}"; then
-      echo "Successfully enabled $TARGET_PLUGIN"
+  for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | grep -o -e "[^;]*"); do
+    echo "Moving ${target_plugin} to plugin directory"
+    plugin_name=${target_plugin%.jar}
+    if mkdir -p "${FLINK_HOME}/plugins/${plugin_name}" && cp "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"; then
+      echo "Successfully enabled ${target_plugin}"
     else
-      echo "Failed to enable $TARGET_PLUGIN. Exiting."
+      echo "Failed to enable ${target_plugin}. Exiting."
       exit 1
     fi
   done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,7 +41,7 @@ copy_plugins_if_required() {
   fi
 
   echo "Enabling required built-in plugins"
-  for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | grep -o -e "[^;]*"); do
+  for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | tr ';' ' '); do
     echo "Linking ${target_plugin} to plugin directory"
     plugin_name=${target_plugin%.jar}
     if mkdir -p "${FLINK_HOME}/plugins/${plugin_name}" && ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,9 +42,9 @@ copy_plugins_if_required() {
 
   echo "Enabling required built-in plugins"
   for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | grep -o -e "[^;]*"); do
-    echo "Moving ${target_plugin} to plugin directory"
+    echo "Linking ${target_plugin} to plugin directory"
     plugin_name=${target_plugin%.jar}
-    if mkdir -p "${FLINK_HOME}/plugins/${plugin_name}" && cp "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"; then
+    if mkdir -p "${FLINK_HOME}/plugins/${plugin_name}" && ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"; then
       echo "Successfully enabled ${target_plugin}"
     else
       echo "Failed to enable ${target_plugin}. Exiting."

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -44,11 +44,14 @@ copy_plugins_if_required() {
   for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | tr ';' ' '); do
     echo "Linking ${target_plugin} to plugin directory"
     plugin_name=${target_plugin%.jar}
-    if mkdir -p "${FLINK_HOME}/plugins/${plugin_name}" && ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"; then
-      echo "Successfully enabled ${target_plugin}"
-    else
-      echo "Failed to enable ${target_plugin}. Exiting."
+
+    mkdir -p "${FLINK_HOME}/plugins/${plugin_name}"
+    if [ ! -e "${FLINK_HOME}/opt/${target_plugin}" ]; then
+      echo "Plugin ${target_plugin} does not exist. Exiting."
       exit 1
+    else
+      ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"
+      echo "Successfully enabled ${target_plugin}"
     fi
   done
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -39,7 +39,8 @@ copy_plugins_if_required() {
   echo "Enabling required built-in plugins"
   for TARGET_PLUGIN in $(echo "$ENABLE_BUILT_IN_PLUGINS" | grep -o -e "[^;]*"); do
     echo "Moving $TARGET_PLUGIN to plugin directory"
-    if cp "${FLINK_HOME}/opt/${TARGET_PLUGIN}" "${FLINK_HOME}/plugins"; then
+    PLUGIN_NAME=${TARGET_PLUGIN%.jar}
+    if mkdir "${FLINK_HOME}/plugins/${PLUGIN_NAME}" && cp "${FLINK_HOME}/opt/${TARGET_PLUGIN}" "${FLINK_HOME}/plugins/${PLUGIN_NAME}"; then
       echo "Successfully enabled $TARGET_PLUGIN"
     else
       echo "Failed to enable $TARGET_PLUGIN. Exiting."

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,11 +36,15 @@ drop_privs_cmd() {
 }
 
 copy_plugins_if_required() {
-  echo "Checking for required user plugins"
-  ENABLE_BUILT_IN_PLUGINS=${ENABLE_BUILT_IN_PLUGINS}
+  echo "Enabling required built-in plugins"
   for TARGET_PLUGIN in $(echo "$ENABLE_BUILT_IN_PLUGINS" | grep -o -e "[^;]*"); do
     echo "Moving $TARGET_PLUGIN to plugin directory"
-    cp "${FLINK_HOME}/opt/${TARGET_PLUGIN}" "${FLINK_HOME}/plugins" && echo "Successfully copied $TARGET_PLUGIN"
+    if cp "${FLINK_HOME}/opt/${TARGET_PLUGIN}" "${FLINK_HOME}/plugins"; then
+      echo "Successfully enabled $TARGET_PLUGIN"
+    else
+      echo "Failed to enable $TARGET_PLUGIN. Exiting."
+      exit 1
+    fi
   done
 }
 


### PR DESCRIPTION
Hey Guys,

I've added some lightweight logic to the `docker-entrypoint.sh` file to allow easy configuration and usage of the plugins that come pre-packaged with the Flink distribution. For our use-case specifically we need the S3 Filesystem plugin for our AWS ECS-hosted cluster.

To use the new variable, you provide a list of all the jars you want moved from the `flink/opt` folder to the `flink/plugins` folder, delimited by semicolons. So, for example: 

```
ENABLE_BUILT_IN_PLUGINS=flink-s3-fs-presto-1.9.1.jar;flink-s3-fs-hadoop-1.9.1.jar
```

If you don't provide the variable, nothing happens.
If you provide the variable but point to a jar NOT present in `flink/opt` then the container will fail to start.

I would really appreciate a speedy review and merge of this as it is currently blocking us. I am ready to make any changes required at the drop of a hat. Just let me know.

Tom